### PR TITLE
Fix: Improve Result Screen UI and integrate feedback widget

### DIFF
--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -38,6 +38,8 @@ class _ResultScreenState extends State<ResultScreen> with SingleTickerProviderSt
   bool _isAutoSaving = false;
   bool _showingClassificationFeedback = true;
   bool _showingPointsPopup = false;
+  bool _isExplanationExpanded = false; // Added for expandable explanation
+  bool _isEducationalFactExpanded = false; // Added for expandable educational fact
   
   List<Achievement> _newlyEarnedAchievements = [];
   int _pointsEarned = 0;
@@ -528,6 +530,8 @@ class _ResultScreenState extends State<ResultScreen> with SingleTickerProviderSt
                                     const SizedBox(height: 4),
                                     Text(
                                       widget.classification.itemName,
+                                      maxLines: 2, // Added maxLines
+                                      overflow: TextOverflow.ellipsis, // Added ellipsis
                                       style: const TextStyle(
                                         fontSize: AppTheme.fontSizeExtraLarge,
                                         fontWeight: FontWeight.bold,
@@ -591,10 +595,27 @@ class _ResultScreenState extends State<ResultScreen> with SingleTickerProviderSt
                                 const SizedBox(height: AppTheme.paddingSmall),
                                 Text(
                                   widget.classification.explanation,
+                                  maxLines: _isExplanationExpanded ? null : 3,
+                                  overflow: _isExplanationExpanded ? TextOverflow.visible : TextOverflow.ellipsis,
                                   style: TextStyle(
                                     fontSize: AppTheme.fontSizeRegular,
                                     color: const Color(0xFF212121), // Almost black for readability
                                     height: 1.5,
+                                  ),
+                                ),
+                                const SizedBox(height: AppTheme.paddingSmall),
+                                GestureDetector(
+                                  onTap: () {
+                                    setState(() {
+                                      _isExplanationExpanded = !_isExplanationExpanded;
+                                    });
+                                  },
+                                  child: Text(
+                                    _isExplanationExpanded ? 'Show Less' : 'Read More',
+                                    style: TextStyle(
+                                      color: AppTheme.primaryColor,
+                                      fontWeight: FontWeight.bold,
+                                    ),
                                   ),
                                 ),
                               ],
@@ -609,11 +630,11 @@ class _ResultScreenState extends State<ResultScreen> with SingleTickerProviderSt
                               children: [
                                 Expanded(
                                   child: ElevatedButton.icon(
-                                    onPressed: _isAutoSaving 
+                                    onPressed: _isAutoSaving
                                         ? null // Disabled while auto-saving
                                         : (_isSaved ? _shareResult : _saveResult),
                                     style: ElevatedButton.styleFrom(
-                                      backgroundColor: _isAutoSaving 
+                                      backgroundColor: _isAutoSaving
                                           ? Colors.grey // Neutral color when saving
                                           : (_isSaved ? AppTheme.primaryColor : Colors.green), // Green for Save, Primary for Share
                                       foregroundColor: Colors.white,
@@ -623,13 +644,13 @@ class _ResultScreenState extends State<ResultScreen> with SingleTickerProviderSt
                                       ),
                                     ),
                                     icon: Icon(
-                                      _isAutoSaving 
+                                      _isAutoSaving
                                           ? Icons.hourglass_empty // Saving icon
                                           : (_isSaved ? Icons.share : Icons.save)
                                     ),
                                     label: Text(
-                                      _isAutoSaving 
-                                          ? 'Saving...' 
+                                      _isAutoSaving
+                                          ? 'Saving...'
                                           : (_isSaved ? 'Share' : 'Save')
                                     ),
                                   ),
@@ -716,7 +737,7 @@ class _ResultScreenState extends State<ResultScreen> with SingleTickerProviderSt
                     ClassificationFeedbackWidget(
                       classification: widget.classification,
                       onFeedbackSubmitted: _handleFeedbackSubmission,
-                      showCompactVersion: true,
+                      showCompactVersion: false, // Changed to false
                     ),
                     const SizedBox(height: AppTheme.paddingLarge),
                   ],
@@ -769,10 +790,27 @@ class _ResultScreenState extends State<ResultScreen> with SingleTickerProviderSt
                               widget.classification.category,
                               widget.classification.subcategory,
                             ),
+                            maxLines: _isEducationalFactExpanded ? null : 3, // Added maxLines
+                            overflow: _isEducationalFactExpanded ? TextOverflow.visible : TextOverflow.ellipsis, // Added ellipsis
                             style: TextStyle(
                               fontSize: AppTheme.fontSizeRegular,
                               height: 1.6,
                               color: AppTheme.textPrimaryColor,
+                            ),
+                          ),
+                          const SizedBox(height: AppTheme.paddingSmall), // Adjusted padding
+                          GestureDetector(
+                            onTap: () {
+                              setState(() {
+                                _isEducationalFactExpanded = !_isEducationalFactExpanded;
+                              });
+                            },
+                            child: Text(
+                              _isEducationalFactExpanded ? 'Show Less' : 'Read More',
+                              style: TextStyle(
+                                color: AppTheme.primaryColor,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
                           ),
                           const SizedBox(height: AppTheme.paddingRegular),

--- a/lib/widgets/disposal_instructions_widget.dart
+++ b/lib/widgets/disposal_instructions_widget.dart
@@ -70,6 +70,8 @@ class _DisposalInstructionsWidgetState extends State<DisposalInstructionsWidget>
                       ),
                       Text(
                         widget.instructions.primaryMethod,
+                        maxLines: 2, // Added maxLines
+                        overflow: TextOverflow.ellipsis, // Added ellipsis
                         style: TextStyle(
                           fontSize: AppTheme.fontSizeRegular,
                           color: Colors.white70,
@@ -213,6 +215,8 @@ class _DisposalInstructionsWidgetState extends State<DisposalInstructionsWidget>
                   Expanded(
                     child: Text(
                       warning,
+                      maxLines: 3, // Added maxLines
+                      overflow: TextOverflow.ellipsis, // Added ellipsis
                       style: TextStyle(
                         fontSize: AppTheme.fontSizeRegular,
                         color: Colors.red.shade700,
@@ -278,6 +282,8 @@ class _DisposalInstructionsWidgetState extends State<DisposalInstructionsWidget>
           Expanded(
             child: Text(
               step,
+              maxLines: 3, // Added maxLines
+              overflow: TextOverflow.ellipsis, // Added ellipsis
               style: TextStyle(
                 fontSize: AppTheme.fontSizeRegular,
                 color: isCompleted ? Colors.grey.shade600 : AppTheme.textPrimaryColor,
@@ -336,6 +342,8 @@ class _DisposalInstructionsWidgetState extends State<DisposalInstructionsWidget>
                   Expanded(
                     child: Text(
                       tip,
+                      maxLines: 3, // Added maxLines
+                      overflow: TextOverflow.ellipsis, // Added ellipsis
                       style: TextStyle(
                         fontSize: AppTheme.fontSizeRegular,
                         color: Colors.blue.shade700,
@@ -384,6 +392,8 @@ class _DisposalInstructionsWidgetState extends State<DisposalInstructionsWidget>
           const SizedBox(height: AppTheme.paddingSmall),
           Text(
             widget.instructions.recyclingInfo!,
+            maxLines: 3, // Added maxLines
+            overflow: TextOverflow.ellipsis, // Added ellipsis
             style: TextStyle(
               fontSize: AppTheme.fontSizeRegular,
               color: Colors.green.shade700,
@@ -427,6 +437,8 @@ class _DisposalInstructionsWidgetState extends State<DisposalInstructionsWidget>
           const SizedBox(height: AppTheme.paddingSmall),
           Text(
             widget.instructions.location!,
+            maxLines: 3, // Added maxLines
+            overflow: TextOverflow.ellipsis, // Added ellipsis
             style: TextStyle(
               fontSize: AppTheme.fontSizeRegular,
               color: Colors.orange.shade700,

--- a/test/screens/result_screen_test.dart
+++ b/test/screens/result_screen_test.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:waste_segregation_app/models/waste_classification.dart';
+import 'package:waste_segregation_app/screens/result_screen.dart';
+import 'package:waste_segregation_app/widgets/classification_feedback_widget.dart';
+import 'package:waste_segregation_app/services/storage_service.dart'; // Mock needed
+import 'package:waste_segregation_app/services/gamification_service.dart'; // Mock needed
+import 'package:mockito/mockito.dart';
+
+// Mocks
+class MockStorageService extends Mock implements StorageService {}
+class MockGamificationService extends Mock implements GamificationService {}
+
+// Helper to create a WasteClassification object with varying text lengths
+WasteClassification createMockClassification({
+  String itemName = 'Default Item Name',
+  String category = 'Default Category',
+  String subcategory = 'Default Subcategory',
+  String explanation = 'Default explanation.',
+  String educationalFact = 'Default educational fact.',
+  DisposalInstructions? disposalInstructions,
+}) {
+  return WasteClassification(
+    id: 'test_id_${DateTime.now().millisecondsSinceEpoch}',
+    itemName: itemName,
+    category: category,
+    subcategory: subcategory,
+    explanation: explanation,
+    disposalInstructions: disposalInstructions ?? DisposalInstructions(primaryMethod: 'Dispose carefully', steps: ['Step 1']),
+    materialType: 'Organic',
+    isRecyclable: false,
+    isCompostable: true,
+    requiresSpecialDisposal: false,
+    recyclingCode: null,
+    environmentalImpact: 'Low impact',
+    recoveryOptions: 'Compost',
+    reductionTips: ['Reduce usage'],
+    sustainabilityFacts: [educationalFact], // Simplification: using sustainabilityFacts for educationalFact
+    typicalLocation: 'Kitchen',
+    commonMistakes: ['Mixing with dry waste'],
+    localRegulations: 'Follow local guidelines',
+    imageUrl: null,
+    timestamp: DateTime.now(),
+    region: 'Test Region',
+    confidence: 0.9,
+    alternativeDisposalMethods: [],
+    historicalSignificance: 'None',
+    culturalSignificance: 'None',
+    safetyWarnings: [],
+    visualFeatures: [],
+    userFeedback: [],
+    source: 'test',
+    isSaved: false,
+    hasUrgentTimeframe: false,
+  );
+}
+
+void main() {
+  late MockStorageService mockStorageService;
+  late MockGamificationService mockGamificationService;
+
+  setUp(() {
+    mockStorageService = MockStorageService();
+    mockGamificationService = MockGamificationService();
+  });
+
+  Widget createTestableWidget(Widget child) {
+    return MultiProvider(
+      providers: [
+        Provider<StorageService>.value(value: mockStorageService),
+        Provider<GamificationService>.value(value: mockGamificationService),
+      ],
+      child: MaterialApp(
+        home: Scaffold(body: child),
+      ),
+    );
+  }
+
+  group('ResultScreen Tests', () {
+    group('Item Name Overflow', () {
+      testWidgets('Item name uses ellipsis for long names', (WidgetTester tester) async {
+        final longItemName = 'This is a very very very extremely long item name that should definitely overflow and show an ellipsis';
+        final classification = createMockClassification(itemName: longItemName);
+
+        await tester.pumpWidget(createTestableWidget(ResultScreen(classification: classification)));
+        await tester.pumpAndSettle(); // Allow time for layout
+
+        final itemNameTextWidget = tester.widget<Text>(find.text(longItemName));
+
+        expect(itemNameTextWidget.overflow, TextOverflow.ellipsis);
+        expect(itemNameTextWidget.maxLines, 2); // As per implementation
+      });
+    });
+
+    group('ClassificationFeedbackWidget Integration', () {
+      testWidgets('Feedback widget is present and configured when showActions is true', (WidgetTester tester) async {
+        final classification = createMockClassification();
+        await tester.pumpWidget(createTestableWidget(ResultScreen(classification: classification, showActions: true)));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ClassificationFeedbackWidget), findsOneWidget);
+        final feedbackWidget = tester.widget<ClassificationFeedbackWidget>(find.byType(ClassificationFeedbackWidget));
+        expect(feedbackWidget.showCompactVersion, isFalse); // As per recent change
+      });
+
+      testWidgets('Feedback widget is NOT present when showActions is false', (WidgetTester tester) async {
+        final classification = createMockClassification();
+        await tester.pumpWidget(createTestableWidget(ResultScreen(classification: classification, showActions: false)));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ClassificationFeedbackWidget), findsNothing);
+      });
+    });
+
+    group('Explanation Read More/Show Less', () {
+      final longExplanation = 'This is a very long explanation that spans multiple lines and should definitely be truncated initially. It needs to be long enough to ensure that the ellipsis is applied and the Read More button is shown. We will then tap the button to expand it and see the full content, and then tap Show Less to collapse it again.';
+      final classificationWithLongExplanation = createMockClassification(explanation: longExplanation);
+
+      testWidgets('Explanation is initially truncated and shows "Read More"', (WidgetTester tester) async {
+        await tester.pumpWidget(createTestableWidget(ResultScreen(classification: classificationWithLongExplanation)));
+        await tester.pumpAndSettle();
+
+        final explanationTextWidget = tester.widget<Text>(find.text(longExplanation));
+        expect(explanationTextWidget.overflow, TextOverflow.ellipsis);
+        expect(explanationTextWidget.maxLines, 3); // As per implementation
+        expect(find.text('Read More'), findsOneWidget);
+        expect(find.text('Show Less'), findsNothing);
+      });
+
+      testWidgets('Tapping "Read More" expands explanation and shows "Show Less"', (WidgetTester tester) async {
+        await tester.pumpWidget(createTestableWidget(ResultScreen(classification: classificationWithLongExplanation)));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Read More'));
+        await tester.pumpAndSettle();
+
+        final explanationTextWidget = tester.widget<Text>(find.text(longExplanation));
+        expect(explanationTextWidget.maxLines, isNull); // Expanded
+        expect(explanationTextWidget.overflow, TextOverflow.visible);
+        expect(find.text('Show Less'), findsOneWidget);
+        expect(find.text('Read More'), findsNothing);
+      });
+
+      testWidgets('Tapping "Show Less" collapses explanation and shows "Read More"', (WidgetTester tester) async {
+        await tester.pumpWidget(createTestableWidget(ResultScreen(classification: classificationWithLongExplanation)));
+        await tester.pumpAndSettle();
+
+        // Expand first
+        await tester.tap(find.text('Read More'));
+        await tester.pumpAndSettle();
+        expect(find.text('Show Less'), findsOneWidget);
+
+        // Then collapse
+        await tester.tap(find.text('Show Less'));
+        await tester.pumpAndSettle();
+
+        final explanationTextWidget = tester.widget<Text>(find.text(longExplanation));
+        expect(explanationTextWidget.overflow, TextOverflow.ellipsis);
+        expect(explanationTextWidget.maxLines, 3);
+        expect(find.text('Read More'), findsOneWidget);
+        expect(find.text('Show Less'), findsNothing);
+      });
+    });
+
+    group('Educational Fact Read More/Show Less', () {
+      final longEducationalFact = 'This is a very long educational fact that also spans multiple lines and is designed to be truncated. It must be sufficiently lengthy to trigger the ellipsis and display the Read More button. Users can then expand it to read the full fact and subsequently collapse it using the Show Less button.';
+      // We use sustainabilityFacts in the mock, which maps to educationalFact in the UI logic
+      final classificationWithLongFact = createMockClassification(educationalFact: longEducationalFact);
+
+
+      testWidgets('Educational Fact is initially truncated and shows "Read More"', (WidgetTester tester) async {
+        await tester.pumpWidget(createTestableWidget(ResultScreen(classification: classificationWithLongFact)));
+        await tester.pumpAndSettle();
+
+        // The actual text displayed comes from _getEducationalFact, which uses classification.sustainabilityFacts.
+        // We need to find the text that _getEducationalFact would produce.
+        // For simplicity in testing, we'll assume the passed educationalFact string is directly rendered.
+        // In a more complex scenario, we might need to mock _getEducationalFact or use more specific finders.
+        final factTextWidget = tester.widget<Text>(find.text(longEducationalFact));
+        expect(factTextWidget.overflow, TextOverflow.ellipsis);
+        expect(factTextWidget.maxLines, 3); // As per implementation
+        expect(find.text('Read More'), findsOneWidget); // This one is for explanation
+        expect(find.widgetWithText(GestureDetector, 'Read More').at(1), findsOneWidget); // Find the second "Read More"
+      });
+
+      testWidgets('Tapping "Read More" on fact expands it and shows "Show Less"', (WidgetTester tester) async {
+        await tester.pumpWidget(createTestableWidget(ResultScreen(classification: classificationWithLongFact)));
+        await tester.pumpAndSettle();
+
+        // Tap the second "Read More" button (for educational fact)
+        await tester.tap(find.widgetWithText(GestureDetector, 'Read More').at(1));
+        await tester.pumpAndSettle();
+
+        final factTextWidget = tester.widget<Text>(find.text(longEducationalFact));
+        expect(factTextWidget.maxLines, isNull); // Expanded
+        expect(factTextWidget.overflow, TextOverflow.visible);
+        expect(find.widgetWithText(GestureDetector, 'Show Less').at(1), findsOneWidget);
+        expect(find.widgetWithText(GestureDetector, 'Read More').at(1), findsNothing);
+      });
+
+      testWidgets('Tapping "Show Less" on fact collapses it and shows "Read More"', (WidgetTester tester) async {
+        await tester.pumpWidget(createTestableWidget(ResultScreen(classification: classificationWithLongFact)));
+        await tester.pumpAndSettle();
+
+        // Expand first
+        await tester.tap(find.widgetWithText(GestureDetector, 'Read More').at(1));
+        await tester.pumpAndSettle();
+        expect(find.widgetWithText(GestureDetector, 'Show Less').at(1), findsOneWidget);
+
+        // Then collapse
+        await tester.tap(find.widgetWithText(GestureDetector, 'Show Less').at(1));
+        await tester.pumpAndSettle();
+
+        final factTextWidget = tester.widget<Text>(find.text(longEducationalFact));
+        expect(factTextWidget.overflow, TextOverflow.ellipsis);
+        expect(factTextWidget.maxLines, 3);
+        expect(find.widgetWithText(GestureDetector, 'Read More').at(1), findsOneWidget);
+        expect(find.widgetWithText(GestureDetector, 'Show Less').at(1), findsNothing);
+      });
+    });
+  });
+}

--- a/test/widgets/disposal_instructions_widget_test.dart
+++ b/test/widgets/disposal_instructions_widget_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:waste_segregation_app/models/waste_classification.dart'; // For DisposalInstructions
+import 'package:waste_segregation_app/widgets/disposal_instructions_widget.dart';
+
+// Helper to create DisposalInstructions with varying text lengths
+DisposalInstructions createMockDisposalInstructions({
+  String primaryMethod = 'Default Primary Method.',
+  List<String> warnings = const ['Default warning.'],
+  List<String> steps = const ['Default step 1.'],
+  List<String> tips = const ['Default tip.'],
+  String? recyclingInfo, // Nullable as per model
+  String? location,      // Nullable as per model
+  bool hasUrgentTimeframe = false,
+  String? timeframe,
+  String? estimatedTime,
+}) {
+  return DisposalInstructions(
+    primaryMethod: primaryMethod,
+    warnings: warnings,
+    steps: steps,
+    tips: tips,
+    recyclingInfo: recyclingInfo,
+    location: location,
+    hasUrgentTimeframe: hasUrgentTimeframe,
+    timeframe: timeframe,
+    estimatedTime: estimatedTime,
+  );
+}
+
+void main() {
+  Widget createTestableWidget(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: SingleChildScrollView(child: child)), // Added SingleChildScrollView for long content
+    );
+  }
+
+  group('DisposalInstructionsWidget Text Overflow Tests', () {
+    testWidgets('Long primary disposal method uses ellipsis', (WidgetTester tester) async {
+      final longText = 'This is an extremely long primary disposal method that should definitely overflow the available space and demonstrate the ellipsis truncation at the end of the text block.';
+      final instructions = createMockDisposalInstructions(primaryMethod: longText);
+
+      await tester.pumpWidget(createTestableWidget(DisposalInstructionsWidget(instructions: instructions)));
+      await tester.pumpAndSettle();
+
+      final textWidget = tester.widget<Text>(find.text(longText));
+      expect(textWidget.overflow, TextOverflow.ellipsis);
+      expect(textWidget.maxLines, 2); // As per implementation in previous subtask
+    });
+
+    testWidgets('Long warning text uses ellipsis', (WidgetTester tester) async {
+      final longWarning = 'This is a very very long safety warning that must be displayed to the user, and it is crucial that it truncates properly with an ellipsis if it cannot fit in the allocated space for a single warning item.';
+      final instructions = createMockDisposalInstructions(warnings: [longWarning, 'Short warning.']);
+
+      await tester.pumpWidget(createTestableWidget(DisposalInstructionsWidget(instructions: instructions)));
+      await tester.pumpAndSettle();
+
+      final textWidget = tester.widget<Text>(find.text(longWarning));
+      expect(textWidget.overflow, TextOverflow.ellipsis);
+      expect(textWidget.maxLines, 3); // As per implementation
+    });
+
+    testWidgets('Long step text uses ellipsis', (WidgetTester tester) async {
+      final longStep = 'This describes a very detailed and extremely long step-by-step instruction for waste disposal that will certainly exceed the typical line limits and thus should be truncated using an ellipsis to maintain UI consistency.';
+      final instructions = createMockDisposalInstructions(steps: [longStep, 'Short step.']);
+
+      await tester.pumpWidget(createTestableWidget(DisposalInstructionsWidget(instructions: instructions)));
+      await tester.pumpAndSettle();
+
+      final textWidget = tester.widget<Text>(find.text(longStep));
+      expect(textWidget.overflow, TextOverflow.ellipsis);
+      expect(textWidget.maxLines, 3); // As per implementation
+    });
+
+    testWidgets('Long tip text uses ellipsis', (WidgetTester tester) async {
+      final longTip = 'Here is an exceptionally long and helpful tip regarding waste management and recycling practices that might not fit into the designated area, therefore it should gracefully truncate with an ellipsis.';
+      final instructions = createMockDisposalInstructions(tips: [longTip, 'Short tip.']);
+
+      await tester.pumpWidget(createTestableWidget(DisposalInstructionsWidget(instructions: instructions)));
+      await tester.pumpAndSettle();
+
+      final textWidget = tester.widget<Text>(find.text(longTip));
+      expect(textWidget.overflow, TextOverflow.ellipsis);
+      expect(textWidget.maxLines, 3); // As per implementation
+    });
+
+    testWidgets('Long recycling info text uses ellipsis', (WidgetTester tester) async {
+      final longRecyclingInfo = 'This section contains extraordinarily detailed recycling information, including material specifics, preparation guidelines, and facility locations, which is so extensive that it will require truncation with an ellipsis.';
+      final instructions = createMockDisposalInstructions(recyclingInfo: longRecyclingInfo);
+
+      await tester.pumpWidget(createTestableWidget(DisposalInstructionsWidget(instructions: instructions)));
+      await tester.pumpAndSettle();
+
+      final textWidget = tester.widget<Text>(find.text(longRecyclingInfo));
+      expect(textWidget.overflow, TextOverflow.ellipsis);
+      expect(textWidget.maxLines, 3); // As per implementation
+    });
+
+    testWidgets('Long location info text uses ellipsis', (WidgetTester tester) async {
+      final longLocationInfo = 'The specific location for disposing of this type of waste is at the following address: Plot 123, Industrial Area, Phase 4, Near the very big landmark that everyone knows, Anytown, State, Country, Postal Code XXXXXX, and this text is designed to overflow.';
+      final instructions = createMockDisposalInstructions(location: longLocationInfo);
+
+      await tester.pumpWidget(createTestableWidget(DisposalInstructionsWidget(instructions: instructions)));
+      await tester.pumpAndSettle();
+
+      final textWidget = tester.widget<Text>(find.text(longLocationInfo));
+      expect(textWidget.overflow, TextOverflow.ellipsis);
+      expect(textWidget.maxLines, 3); // As per implementation
+    });
+  });
+}


### PR DESCRIPTION
This commit addresses two UI improvements on the Result Screen:

1.  **Text Overflow Resolution:**
    - Implemented "Read More"/"Show Less" functionality for the explanation and educational fact sections in `result_screen.dart` to prevent text overflow and improve readability.
    - Applied `TextOverflow.ellipsis` to item names in `result_screen.dart` and to various text fields within `disposal_instructions_widget.dart` (primary method, warnings, steps, tips, recycling info, location info) to ensure they truncate gracefully.

2.  **User Feedback Widget Integration:**
    - Made the `ClassificationFeedbackWidget` more prominent on the `result_screen.dart` by setting its `showCompactVersion` property to `false`. This ensures you can easily see and use the feedback mechanism.

Widget tests have been added to verify the text overflow handling, the "Read More"/"Show Less" interactions, and the correct display of the feedback widget based on the `showActions` flag and `showCompactVersion` property.