### PR TITLE
Implement color extension for opacity

### DIFF
--- a/lib/utils/color_extensions.dart
+++ b/lib/utils/color_extensions.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// Extension methods for manipulating ARGB values of a [Color].
+extension ColorValues on Color {
+  /// Returns a new color with any provided channel values replaced.
+  ///
+  /// The [alpha] value is expected to be between 0 and 1.
+  Color withValues({double? alpha, int? red, int? green, int? blue}) {
+    final a = alpha != null
+        ? (alpha.clamp(0.0, 1.0) * 255).round()
+        : this.alpha;
+    return Color.fromARGB(
+      a,
+      red ?? this.red,
+      green ?? this.green,
+      blue ?? this.blue,
+    );
+  }
+}

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+
+// Export color utilities so widgets importing constants get access to
+// the modern Color.withValues extension without an extra import.
+export 'color_extensions.dart';
 // import 'package:firebase_crashlytics/firebase_crashlytics.dart'; // ErrorHandler should not be in constants
 // import '../utils/error_handler.dart'; // Ensure ErrorHandler is not imported here
 


### PR DESCRIPTION
## Summary
- add `ColorValues` extension for setting alpha/red/green/blue
- export color extension from `constants.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412442333c8323979ba3c250ce42e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new method for colors that allows you to easily adjust transparency and color channels (alpha, red, green, blue) when working with colors.
- **Chores**
  - Made color utilities more accessible throughout the app by updating exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->