### PR TITLE
Fix widget tree integration test

### DIFF
--- a/test/services/ad_service_test.dart
+++ b/test/services/ad_service_test.dart
@@ -365,7 +365,8 @@ void main() {
     });
 
     group('Integration Tests', () {
-      test('should integrate correctly with Flutter widget tree', () async {
+      testWidgets('should integrate correctly with Flutter widget tree',
+          (WidgetTester tester) async {
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
@@ -373,9 +374,9 @@ void main() {
             ),
           ),
         );
-        
+
         expect(find.byType(Scaffold), findsOneWidget);
-      }, skip: 'Requires widget tester');
+      });
 
       test('should work with ChangeNotifier pattern', () {
         var listenerCalled = false;


### PR DESCRIPTION
## Summary
- integrate the banner ad widget using `testWidgets`
- remove the skip flag so test executes

## Testing
- `flutter test test/services/ad_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412753fee88323a0665f03d2f7e183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated an integration test to use widget testing, ensuring it runs within the Flutter widget testing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->