### PR TITLE
Fix integration tests and caching alias

### DIFF
--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -461,3 +461,8 @@ class ClassificationCacheService {
     }
   }
 }
+
+/// Temporary alias to maintain compatibility with older tests that referenced
+/// `CacheService`. This alias maps the old name to the current
+/// `ClassificationCacheService` implementation.
+typedef CacheService = ClassificationCacheService;

--- a/lib/services/community_service.dart
+++ b/lib/services/community_service.dart
@@ -3,6 +3,8 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import '../models/community_feed.dart';
+import '../models/waste_classification.dart';
+import '../models/user_profile.dart';
 
 /// Service for managing community feed and social features
 class CommunityService {
@@ -176,6 +178,19 @@ class CommunityService {
     );
     
     await addFeedItem(feedItem);
+  }
+
+  /// Track a classification activity for a given user. This is a lightweight
+  /// wrapper around [recordClassification] used in tests.
+  Future<void> trackClassificationActivity(
+    WasteClassification classification,
+    UserProfile user,
+  ) async {
+    await recordClassification(
+      classification.category,
+      classification.subcategory ?? '',
+      0,
+    );
   }
   
   /// Generate sample community data to make the feed feel active

--- a/test/integration/full_workflow_integration_test.dart
+++ b/test/integration/full_workflow_integration_test.dart
@@ -405,7 +405,7 @@ void main() {
             type: AchievementType.wasteIdentified,
             threshold: 100,
             iconName: 'star',
-            color: Colors.gold,
+            color: Colors.amber,
             progress: 1.0,
           )),
         );


### PR DESCRIPTION
## Summary
- alias `CacheService` to `ClassificationCacheService`
- add helper `trackClassificationActivity` to community service
- fix invalid color constant in `full_workflow_integration_test`

## Testing
- `flutter test test/services/cache_service_test.dart` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684129eea85883239b3a290aa32f224a