### PR TITLE
Add notification settings screen

### DIFF
--- a/lib/screens/notification_settings_screen.dart
+++ b/lib/screens/notification_settings_screen.dart
@@ -40,9 +40,9 @@ class _NotificationSettingsScreenState extends State<NotificationSettingsScreen>
     final settings = await storage.getSettings();
     await storage.saveSettings(
       isDarkMode: settings['isDarkMode'] ?? false,
-      isGoogleSyncEnabled: settings['isGoogleSyncEnabled'] ?? true,
-      allowHistoryFeedback: settings['allowHistoryFeedback'],
-      feedbackTimeframeDays: settings['feedbackTimeframeDays'],
+      isGoogleSyncEnabled: settings['isGoogleSyncEnabled'] ?? false,
+      allowHistoryFeedback: settings['allowHistoryFeedback'] ?? true,
+      feedbackTimeframeDays: settings['feedbackTimeframeDays'] ?? 7,
       notifications: _notificationsEnabled,
       eduNotifications: _educationalEnabled,
       gamificationNotifications: _gamificationEnabled,

--- a/lib/screens/notification_settings_screen.dart
+++ b/lib/screens/notification_settings_screen.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/storage_service.dart';
+
+class NotificationSettingsScreen extends StatefulWidget {
+  const NotificationSettingsScreen({super.key});
+
+  @override
+  State<NotificationSettingsScreen> createState() => _NotificationSettingsScreenState();
+}
+
+class _NotificationSettingsScreenState extends State<NotificationSettingsScreen> {
+  bool _notificationsEnabled = true;
+  bool _educationalEnabled = true;
+  bool _gamificationEnabled = true;
+  bool _reminderEnabled = true;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  Future<void> _loadSettings() async {
+    final storage = Provider.of<StorageService>(context, listen: false);
+    final settings = await storage.getSettings();
+    setState(() {
+      _notificationsEnabled = settings['notifications'] ?? true;
+      _educationalEnabled = settings['eduNotifications'] ?? true;
+      _gamificationEnabled = settings['gamificationNotifications'] ?? true;
+      _reminderEnabled = settings['reminderNotifications'] ?? true;
+      _loading = false;
+    });
+  }
+
+  Future<void> _saveSettings() async {
+    final storage = Provider.of<StorageService>(context, listen: false);
+    final settings = await storage.getSettings();
+    await storage.saveSettings(
+      isDarkMode: settings['isDarkMode'] ?? false,
+      isGoogleSyncEnabled: settings['isGoogleSyncEnabled'] ?? true,
+      allowHistoryFeedback: settings['allowHistoryFeedback'],
+      feedbackTimeframeDays: settings['feedbackTimeframeDays'],
+      notifications: _notificationsEnabled,
+      eduNotifications: _educationalEnabled,
+      gamificationNotifications: _gamificationEnabled,
+      reminderNotifications: _reminderEnabled,
+    );
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Notification settings saved')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Notification Settings'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.save),
+            onPressed: _saveSettings,
+          ),
+        ],
+      ),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Enable Notifications'),
+            value: _notificationsEnabled,
+            onChanged: (value) {
+              setState(() {
+                _notificationsEnabled = value;
+              });
+            },
+          ),
+          const Divider(),
+          SwitchListTile(
+            title: const Text('Educational Content'),
+            value: _educationalEnabled,
+            onChanged: _notificationsEnabled
+                ? (value) {
+                    setState(() {
+                      _educationalEnabled = value;
+                    });
+                  }
+                : null,
+          ),
+          SwitchListTile(
+            title: const Text('Gamification'),
+            value: _gamificationEnabled,
+            onChanged: _notificationsEnabled
+                ? (value) {
+                    setState(() {
+                      _gamificationEnabled = value;
+                    });
+                  }
+                : null,
+          ),
+          SwitchListTile(
+            title: const Text('Reminders'),
+            value: _reminderEnabled,
+            onChanged: _notificationsEnabled
+                ? (value) {
+                    setState(() {
+                      _reminderEnabled = value;
+                    });
+                  }
+                : null,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -19,6 +19,7 @@ import 'data_export_screen.dart';
 import 'navigation_demo_screen.dart';
 import 'modern_ui_showcase_screen.dart';
 import 'auth_screen.dart';
+import 'notification_settings_screen.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import '../services/cloud_storage_service.dart';
 
@@ -294,6 +295,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 context,
                 MaterialPageRoute(
                   builder: (context) => const ThemeSettingsScreen(),
+                ),
+              );
+            },
+          ),
+          const Divider(),
+
+          // Notification Settings
+          ListTile(
+            leading: const Icon(Icons.notifications),
+            title: const Text('Notification Settings'),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const NotificationSettingsScreen(),
                 ),
               );
             },

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -560,6 +560,10 @@ class StorageService {
     required bool isGoogleSyncEnabled,
     bool? allowHistoryFeedback,
     int? feedbackTimeframeDays,
+    bool? notifications,
+    bool? eduNotifications,
+    bool? gamificationNotifications,
+    bool? reminderNotifications,
   }) async {
     final settings = await getSettings();
     
@@ -573,6 +577,18 @@ class StorageService {
     }
     if (feedbackTimeframeDays != null) {
       settings['feedbackTimeframeDays'] = feedbackTimeframeDays;
+    }
+    if (notifications != null) {
+      settings['notifications'] = notifications;
+    }
+    if (eduNotifications != null) {
+      settings['eduNotifications'] = eduNotifications;
+    }
+    if (gamificationNotifications != null) {
+      settings['gamificationNotifications'] = gamificationNotifications;
+    }
+    if (reminderNotifications != null) {
+      settings['reminderNotifications'] = reminderNotifications;
     }
     
     // Save the updated settings
@@ -592,6 +608,9 @@ class StorageService {
         // Default settings for new users - Cloud sync ENABLED by default
         final defaultSettings = {
           'notifications': true,
+          'eduNotifications': true,
+          'gamificationNotifications': true,
+          'reminderNotifications': true,
           'darkMode': false,
           'soundEffects': true,
           'autoSave': true,
@@ -608,6 +627,9 @@ class StorageService {
       // Return default settings with cloud sync enabled
       return {
         'notifications': true,
+        'eduNotifications': true,
+        'gamificationNotifications': true,
+        'reminderNotifications': true,
         'darkMode': false,
         'soundEffects': true,
         'autoSave': true,


### PR DESCRIPTION
## Summary
- implement notification settings screen with master and category toggles
- extend storage service to store notification settings
- link notification settings screen from Settings

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684152c2eef08323814a02abcd0591ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Notification Settings screen where users can customize their notification preferences, including toggles for general, educational, gamification, and reminder notifications.
  - Introduced a new "Notification Settings" entry in the main settings menu for easier access.

- **Enhancements**
  - Notification preferences are now saved and loaded with other app settings, ensuring persistence across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->