### PR TITLE
Modernize social screen

### DIFF
--- a/lib/screens/social_screen.dart
+++ b/lib/screens/social_screen.dart
@@ -9,47 +9,42 @@ class SocialScreen extends StatefulWidget {
   State<SocialScreen> createState() => _SocialScreenState();
 }
 
-class _SocialScreenState extends State<SocialScreen> with TickerProviderStateMixin {
-  late TabController _tabController;
+class _SocialScreenState extends State<SocialScreen> {
+  int _currentIndex = 0;
 
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(length: 2, vsync: this);
-  }
-
-  @override
-  void dispose() {
-    _tabController.dispose();
-    super.dispose();
-  }
+  static const _screens = [
+    CommunityScreen(),
+    FamilyDashboardScreen(),
+  ];
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Social'),
-        bottom: TabBar(
-          controller: _tabController,
-          tabs: const [
-            Tab(
-              icon: Icon(Icons.people),
-              text: 'Community',
-            ),
-            Tab(
-              icon: Icon(Icons.family_restroom),
-              text: 'Family',
-            ),
-          ],
-        ),
       ),
-      body: TabBarView(
-        controller: _tabController,
-        children: const [
-          CommunityScreen(),
-          FamilyDashboardScreen(),
+      body: IndexedStack(
+        index: _currentIndex,
+        children: _screens,
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _currentIndex,
+        onDestinationSelected: (index) {
+          setState(() => _currentIndex = index);
+        },
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.people_outline),
+            selectedIcon: Icon(Icons.people),
+            label: 'Community',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.family_restroom_outlined),
+            selectedIcon: Icon(Icons.family_restroom),
+            label: 'Family',
+          ),
         ],
       ),
     );
   }
-} 
+}


### PR DESCRIPTION
## Summary
- use Material3 `NavigationBar` for the social screen

## Testing
- `./test_runner.sh` *(fails: Flutter is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684183d50bac832380f70d776ec170be

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a bottom navigation bar for switching between Community and Family Dashboard screens.
  - Updated navigation icons to display distinct visuals for selected and unselected states.

- **Refactor**
  - Improved navigation by replacing the top tab bar with a more intuitive bottom navigation bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->