### PR TITLE
Implement profile screen

### DIFF
--- a/lib/screens/modern_home_screen.dart
+++ b/lib/screens/modern_home_screen.dart
@@ -22,6 +22,7 @@ import 'educational_content_screen.dart';
 import 'achievements_screen.dart';
 import 'waste_dashboard_screen.dart';
 import 'settings_screen.dart';
+import 'profile_screen.dart';
 import 'social_screen.dart';
 import 'disposal_facilities_screen.dart';
 
@@ -561,7 +562,7 @@ class _ModernHomeScreenState extends State<ModernHomeScreen> with TickerProvider
                 case 'profile':
                   Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (context) => const SettingsScreen()),
+                    MaterialPageRoute(builder: (context) => const ProfileScreen()),
                   );
                   break;
                 case 'help':

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/gamification.dart';
+import '../models/user_profile.dart';
+import '../services/storage_service.dart';
+import '../services/gamification_service.dart';
+import '../utils/constants.dart';
+import '../widgets/profile_summary_card.dart';
+
+class ProfileScreen extends StatefulWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  State<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends State<ProfileScreen> {
+  late Future<_ProfileData> _profileFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _profileFuture = _loadData();
+  }
+
+  Future<_ProfileData> _loadData() async {
+    final storageService = Provider.of<StorageService>(context, listen: false);
+    final gamificationService =
+        Provider.of<GamificationService>(context, listen: false);
+
+    // Ensure points haven't fallen behind classifications
+    await gamificationService.syncClassificationPoints();
+
+    final userProfile = await storageService.getCurrentUserProfile();
+    final classifications = await storageService.getAllClassifications();
+    final gamProfile = await gamificationService.getProfile();
+
+    return _ProfileData(
+      userProfile,
+      classifications.length,
+      gamProfile.points,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Profile'),
+      ),
+      body: FutureBuilder<_ProfileData>(
+        future: _profileFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError || !snapshot.hasData) {
+            return const Center(child: Text('Failed to load profile'));
+          }
+
+          final data = snapshot.data!;
+          final profile = data.userProfile;
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(AppTheme.paddingRegular),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                CircleAvatar(
+                  radius: 40,
+                  backgroundImage: profile?.photoUrl != null &&
+                          profile!.photoUrl!.isNotEmpty
+                      ? NetworkImage(profile.photoUrl!)
+                      : null,
+                  child: profile?.photoUrl == null ||
+                          profile.photoUrl!.isEmpty
+                      ? const Icon(Icons.person, size: 40)
+                      : null,
+                ),
+                const SizedBox(height: AppTheme.paddingRegular),
+                if (profile?.displayName != null)
+                  Text(
+                    profile!.displayName!,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                if (profile?.email != null)
+                  Text(
+                    profile!.email!,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                const SizedBox(height: AppTheme.paddingRegular),
+                ProfileSummaryCard(points: data.points),
+                const SizedBox(height: AppTheme.paddingRegular),
+                Card(
+                  child: ListTile(
+                    leading: const Icon(Icons.history),
+                    title: const Text('Classifications'),
+                    trailing: Text('${data.classificationCount}'),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ProfileData {
+  final UserProfile? userProfile;
+  final int classificationCount;
+  final UserPoints points;
+  _ProfileData(this.userProfile, this.classificationCount, this.points);
+}
+

--- a/lib/services/gamification_service.dart
+++ b/lib/services/gamification_service.dart
@@ -434,6 +434,25 @@ class GamificationService {
     debugPrint('✨ Points added: $pointsToAdd for $action. New total: $newTotal. Level: $newLevel');
     return newPoints;
   }
+
+  /// Ensure points reflect the number of classifications recorded.
+  /// If classifications exceed points earned, award the missing points.
+  Future<void> syncClassificationPoints() async {
+    try {
+      // Get all classifications for the current user
+      final classifications = await _storageService.getAllClassifications();
+      final expected = classifications.length * (_pointValues['classification'] ?? 10);
+
+      final profile = await getProfile();
+      if (profile.points.total < expected) {
+        final diff = expected - profile.points.total;
+        debugPrint('🎮 SYNC: awarding $diff retroactive points');
+        await _addPointsInternal('classification_sync', customPoints: diff);
+      }
+    } catch (e) {
+      debugPrint('🔥 SYNC ERROR: $e');
+    }
+  }
   
   // Process a waste classification for gamification
   // Returns a list of completed challenges


### PR DESCRIPTION
## Summary
- add new `ProfileScreen` with basic user info, points and classification count
- navigate to `ProfileScreen` from the home menu
- sync points with classification history

## Testing
- `bash quick_test.sh` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841831fb87083239b919899bffbe209