### PR TITLE
Ensure classification points resync during gamification sync

### DIFF
--- a/lib/services/gamification_service.dart
+++ b/lib/services/gamification_service.dart
@@ -1564,7 +1564,10 @@ class GamificationService {
   Future<void> syncGamificationData() async {
     try {
       debugPrint('🔄 Syncing gamification data across app components...');
-      
+
+      // Ensure points accurately reflect all stored classifications
+      await syncClassificationPoints();
+
       // Force refresh profile
       final profile = await forceRefreshProfile();
       


### PR DESCRIPTION
## Summary
- re-sync classification points when `syncGamificationData` runs

## Testing
- `bash quick_test.sh` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684190ac3e38832395ffb04cabf44512