### PR TITLE
Fix family join by ID

### DIFF
--- a/lib/screens/family_dashboard_screen.dart
+++ b/lib/screens/family_dashboard_screen.dart
@@ -801,11 +801,17 @@ class _FamilyDashboardScreenState extends State<FamilyDashboardScreen> {
                   // Determine if the entered ID is a direct family ID
                   final existingFamily = await _familyService.getFamily(inviteId);
                   if (existingFamily != null) {
+                    // Check if user is already a member
+                    final isAlreadyMember = existingFamily.members
+                        .any((member) => member.userId == currentUser.id);
+                    if (isAlreadyMember) {
+                      throw Exception('You are already a member of this family.');
+                    }
                     // Join family directly
                     await _familyService.addMember(
                       inviteId,
                       currentUser.id,
-                      currentUser.role ?? user_profile_models.UserRole.member,
+                      user_profile_models.UserRole.member,
                     );
                   } else {
                     // Otherwise attempt to accept an invitation

--- a/lib/screens/family_dashboard_screen.dart
+++ b/lib/screens/family_dashboard_screen.dart
@@ -750,7 +750,7 @@ class _FamilyDashboardScreenState extends State<FamilyDashboardScreen> {
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Text('Enter family invitation ID or family ID:'),
+              const Text('Enter family invitation ID (recommended) or family ID (direct join):'),
               const SizedBox(height: AppTheme.paddingRegular),
               TextField(
                 controller: inviteController,

--- a/lib/screens/family_dashboard_screen.dart
+++ b/lib/screens/family_dashboard_screen.dart
@@ -793,17 +793,28 @@ class _FamilyDashboardScreenState extends State<FamilyDashboardScreen> {
                 try {
                   final storageService = Provider.of<StorageService>(context, listen: false);
                   final currentUser = await storageService.getCurrentUserProfile();
-                  
+
                   if (currentUser == null) {
                     throw Exception('User not found. Please sign in again.');
                   }
 
-                  // Try to accept the invitation
-                  await _familyService.acceptInvitation(inviteId, currentUser.id);
-                  
+                  // Determine if the entered ID is a direct family ID
+                  final existingFamily = await _familyService.getFamily(inviteId);
+                  if (existingFamily != null) {
+                    // Join family directly
+                    await _familyService.addMember(
+                      inviteId,
+                      currentUser.id,
+                      currentUser.role ?? user_profile_models.UserRole.member,
+                    );
+                  } else {
+                    // Otherwise attempt to accept an invitation
+                    await _familyService.acceptInvitation(inviteId, currentUser.id);
+                  }
+
                   navigator.pop();
                   await _initializeFamilyData(); // Refresh the family data
-                  
+
                   if (mounted) {
                     scaffoldMessenger.showSnackBar(
                       const SnackBar(


### PR DESCRIPTION
## Summary
- support joining a family directly via its ID

## Testing
- `bash quick_test.sh` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d5a9f48483239a285ebbff3f5063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the family join process to allow users to join a family directly using a family ID or via an invitation ID.
  - Updated the join family dialog text for clearer instructions on using family or invitation IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->