### PR TITLE
Fix history thumbnails and FAB overlap

### DIFF
--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+import 'dart:io';
 import 'package:provider/provider.dart';
 import '../utils/share_service.dart';
 import '../models/waste_classification.dart';
@@ -623,11 +625,7 @@ class _ResultScreenState extends State<ResultScreen> with SingleTickerProviderSt
                                     ),
                                   ],
                                 ),
-                                child: Icon(
-                                  _getCategoryIcon(widget.classification.category),
-                                  color: Colors.white,
-                                  size: 32,
-                                ),
+                                child: _buildThumbnail(32),
                               ),
                               const SizedBox(width: AppTheme.paddingRegular),
                               Expanded(
@@ -1211,6 +1209,66 @@ class _ResultScreenState extends State<ResultScreen> with SingleTickerProviderSt
       default:
         return Icons.category;
     }
+  }
+
+  /// Builds a thumbnail image for the classification if available
+  Widget _buildThumbnail(double size) {
+    final url = widget.classification.imageUrl;
+    if (url == null || url.isEmpty) {
+      return Icon(
+        _getCategoryIcon(widget.classification.category),
+        color: Colors.white,
+        size: size,
+      );
+    }
+
+    if (kIsWeb) {
+      if (url.startsWith('web_image:')) {
+        final dataUrl = url.substring('web_image:'.length);
+        if (dataUrl.startsWith('data:image')) {
+          return Image.network(
+            dataUrl,
+            height: size,
+            width: size,
+            fit: BoxFit.cover,
+          );
+        }
+      }
+
+      if (url.startsWith('http')) {
+        return Image.network(
+          url,
+          height: size,
+          width: size,
+          fit: BoxFit.cover,
+        );
+      }
+    } else {
+      final file = File(url);
+      if (file.existsSync()) {
+        return Image.file(
+          file,
+          height: size,
+          width: size,
+          fit: BoxFit.cover,
+        );
+      }
+
+      if (url.startsWith('http')) {
+        return Image.network(
+          url,
+          height: size,
+          width: size,
+          fit: BoxFit.cover,
+        );
+      }
+    }
+
+    return Icon(
+      _getCategoryIcon(widget.classification.category),
+      color: Colors.white,
+      size: size,
+    );
   }
 
   String _getEducationalFact(String category, String? subcategory) {

--- a/lib/screens/social_screen.dart
+++ b/lib/screens/social_screen.dart
@@ -108,9 +108,7 @@ class _SocialScreenState extends State<SocialScreen> {
       // Floating action button positioned to avoid bottom nav overlap
       floatingActionButton: Container(
         margin: EdgeInsets.only(
-          bottom: isIOS 
-              ? (bottomPadding > 0 ? bottomPadding + 16 : 32) // iOS safe area + extra padding
-              : 80, // Android bottom nav height + padding
+          bottom: (isIOS ? bottomPadding : 0) + kBottomNavigationBarHeight + 16,
         ),
         child: _currentIndex == 0 
             ? FloatingActionButton.extended(

--- a/lib/widgets/history_list_item.dart
+++ b/lib/widgets/history_list_item.dart
@@ -461,10 +461,30 @@ class HistoryListItem extends StatelessWidget {
         borderRadius: BorderRadius.circular(AppTheme.borderRadiusSmall),
       ),
       child: Icon(
-        Icons.image_not_supported,
+        _getCategoryIcon(),
         color: Colors.grey.shade400,
         size: 24,
       ),
     );
+  }
+
+  /// Returns an icon that represents the classification category
+  IconData _getCategoryIcon() {
+    switch (classification.category.toLowerCase()) {
+      case 'wet waste':
+        return Icons.eco;
+      case 'dry waste':
+        return Icons.recycling;
+      case 'hazardous waste':
+        return Icons.warning;
+      case 'medical waste':
+        return Icons.medical_services;
+      case 'non-waste':
+        return Icons.check_circle;
+      case 'requires manual review':
+        return Icons.help_outline;
+      default:
+        return Icons.category;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- show category icon placeholder in history items
- display classification thumbnail on result screen when available
- adjust FAB bottom margin on social screen for consistent layout

## Testing
- `./test_runner.sh` *(fails: Flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842a4ca739083238afc50e1b689c824