### PR TITLE
Clarify dynamic gamification points status

### DIFF
--- a/docs/guides/build_instructions.md
+++ b/docs/guides/build_instructions.md
@@ -209,6 +209,9 @@ static const Map<String, int> _pointValues = {
   // ...
 };
 ```
+At present these values are hard coded in the service. A more dynamic
+Firestore-driven configuration is planned but not yet implemented, so
+editing this map is the primary way to change point rewards.
 
 ### Customizing the Dashboard
 

--- a/docs/technical/gamification_phase1_implementation_plan.md
+++ b/docs/technical/gamification_phase1_implementation_plan.md
@@ -79,6 +79,7 @@ This section defines how users earn engagement points in Phase 1.
     *   **On Classification:** A Cloud Function triggered when a new successful classification is logged. This function will call `awardPoints` with `actionType: "CLASSIFICATION_SUCCESS"`.
     *   **On Educational Content Completion:** Cloud Functions triggered when an article/video is marked complete, or a quiz attempt is successfully saved. These will call `awardPoints` with appropriate `actionType` (e.g., "ARTICLE_COMPLETE", "QUIZ_COMPLETE", "QUIZ_COMPLETE_HIGH_SCORE").
 *   **Configuration for Point Values:** Point values for basic actions (like classification, article read) can be stored in a configuration document in Firestore (e.g., `app_config/gamification_settings`) that the `awardPoints` function can read. This allows for easier tuning via the Admin Panel later without re-deploying functions. (Note: The `gamification_engagement_strategy.md` provides a more comprehensive list of point-earning actions and dynamic considerations for future enhancements beyond Phase 1).
+    *   *Status:* The current code still relies on a static `_pointValues` map in `GamificationService`. The Firestore-based configuration described here is planned but has not yet been implemented in the app or UI.
 
 ## 4. Badge Implementation (Phase 1)
 

--- a/docs/technical/implementation/gamification_service_revamp.md
+++ b/docs/technical/implementation/gamification_service_revamp.md
@@ -2,6 +2,8 @@
 
 This document outlines the planned changes and enhancements to `lib/services/gamification_service.dart` to implement the dynamic point system and AI-driven discovery features as defined in the main `gamification_engagement_strategy.md`.
 
+**Current Status:** The app presently uses a fixed `_pointValues` map for all rewards. The dynamic system described below is not yet live in the codebase or user interface.
+
 ## 1. Service Dependencies and Initialization
 
 No major changes anticipated to the constructor or `initGamification()` other than ensuring any new Hive boxes or configurations are handled if needed.


### PR DESCRIPTION
## Summary
- document that point values are currently static
- note that dynamic Firestore configuration is still planned
- clarify current status in `gamification_service_revamp` and implementation plan docs

## Testing
- `./quick_test.sh` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842a64d8b2c83238aab47ebc6bc23d0