### PR TITLE
Fix image display on web

### DIFF
--- a/lib/services/enhanced_image_service.dart
+++ b/lib/services/enhanced_image_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
@@ -17,6 +18,12 @@ class EnhancedImageService {
   /// Save raw image bytes to a permanent file location and
   /// return the file path.
   Future<String> saveImagePermanently(Uint8List bytes, {String? fileName}) async {
+    if (kIsWeb) {
+      final base64Data = base64Encode(bytes);
+      // Prefix with custom identifier for easier detection in widgets
+      return 'web_image:data:image/jpeg;base64,$base64Data';
+    }
+
     final dir = await getApplicationDocumentsDirectory();
     final imagesDir = Directory(p.join(dir.path, _imagesDirName));
     if (!await imagesDir.exists()) {

--- a/lib/services/enhanced_image_service.dart
+++ b/lib/services/enhanced_image_service.dart
@@ -16,12 +16,29 @@ class EnhancedImageService {
   static const _imagesDirName = 'images';
 
   /// Save raw image bytes to a permanent file location and
-  /// return the file path.
+  /// return the file path. On web platforms, returns a base64 data URL.
   Future<String> saveImagePermanently(Uint8List bytes, {String? fileName}) async {
     if (kIsWeb) {
       final base64Data = base64Encode(bytes);
+      // Detect image format or default to jpeg
+      String mimeType = 'image/jpeg';
+      if (bytes.length > 4) {
+        // PNG signature: 0x89 0x50 0x4E 0x47
+        if (bytes[0] == 0x89 &&
+            bytes[1] == 0x50 &&
+            bytes[2] == 0x4E &&
+            bytes[3] == 0x47) {
+          mimeType = 'image/png';
+        }
+        // GIF signature: 'G' 'I' 'F'
+        else if (bytes[0] == 0x47 &&
+                 bytes[1] == 0x49 &&
+                 bytes[2] == 0x46) {
+          mimeType = 'image/gif';
+        }
+      }
       // Prefix with custom identifier for easier detection in widgets
-      return 'web_image:data:image/jpeg;base64,$base64Data';
+      return 'web_image:data:$mimeType;base64,$base64Data';
     }
 
     final dir = await getApplicationDocumentsDirectory();


### PR DESCRIPTION
## Summary
- encode images as data URLs on web so analysis cards and history thumbnails load

## Testing
- `./test_runner.sh` *(fails: Flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842e5b74eb083239a0ea51686f73789

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved image saving functionality with platform-specific handling: images are now saved as base64 data URIs on web platforms and as files on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->