### PR TITLE
Fix weekly stats persistence in gamification service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -280,7 +280,7 @@ class WasteSegregationApp extends StatelessWidget {
             value: educationalContentAnalyticsService),
         Provider<GoogleDriveService>.value(value: googleDriveService),
         Provider<EducationalContentService>.value(value: educationalContentService),
-        Provider<GamificationService>.value(value: gamificationService),
+        ChangeNotifierProvider<GamificationService>.value(value: gamificationService),
         ChangeNotifierProvider<PremiumService>.value(value: premiumService),
         ChangeNotifierProvider<AdService>.value(value: adService),
         ChangeNotifierProvider<NavigationSettingsService>.value(value: navigationSettingsService),


### PR DESCRIPTION
## Summary
- ensure weekly stats updates propagate to the stored gamification profile
- broadcast gamification profile changes via ChangeNotifier
- refresh achievements and home screens when profile updates

## Testing
- `./quick_test.sh` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e4c6bafc832394d94ab964c89ca9