### PR TITLE
Add Firestore invitation index

### DIFF
--- a/docs/COMPREHENSIVE_FIXES_SUMMARY.md
+++ b/docs/COMPREHENSIVE_FIXES_SUMMARY.md
@@ -105,7 +105,7 @@ This document provides a comprehensive summary of all fixes, improvements, and i
 | Collection | Index Type | Performance Gain |
 |------------|------------|------------------|
 | families | Composite (familyId + role + joinedAt) | 95% faster |
-| family_invitations | Composite (familyId + status + createdAt) | 90% faster |
+| invitations | Composite (familyId + createdAt) | 90% faster |
 | analytics_events | Composite (userId + eventType + timestamp) | 85% faster |
 | disposal_locations | Composite (source + isActive + name) | 80% faster |
 

--- a/docs/COMPREHENSIVE_FIXES_SUMMARY.md
+++ b/docs/COMPREHENSIVE_FIXES_SUMMARY.md
@@ -105,7 +105,7 @@ This document provides a comprehensive summary of all fixes, improvements, and i
 | Collection | Index Type | Performance Gain |
 |------------|------------|------------------|
 | families | Composite (familyId + role + joinedAt) | 95% faster |
-| invitations | Composite (familyId + createdAt) | 90% faster |
+| invitations | Composite (familyId + status + createdAt) | 90% faster |
 | analytics_events | Composite (userId + eventType + timestamp) | 85% faster |
 | disposal_locations | Composite (source + isActive + name) | 80% faster |
 

--- a/docs/technical/fixes/FAMILY_SYSTEM_IMPLEMENTATION.md
+++ b/docs/technical/fixes/FAMILY_SYSTEM_IMPLEMENTATION.md
@@ -336,6 +336,7 @@ CircleAvatar(
   "collectionGroup": "invitations",
   "fields": [
     {"fieldPath": "familyId", "order": "ASCENDING"},
+    {"fieldPath": "status", "order": "ASCENDING"},
     {"fieldPath": "createdAt", "order": "DESCENDING"}
   ]
 }

--- a/docs/technical/fixes/FAMILY_SYSTEM_IMPLEMENTATION.md
+++ b/docs/technical/fixes/FAMILY_SYSTEM_IMPLEMENTATION.md
@@ -100,7 +100,7 @@ Future<FamilyInvitation> createInvitation(
     expiresAt: DateTime.now().add(Duration(days: 7)),
   );
   
-  await _firestore.collection('family_invitations').doc(invitation.id).set(invitation.toJson());
+  await _firestore.collection('invitations').doc(invitation.id).set(invitation.toJson());
   return invitation;
 }
 ```
@@ -300,7 +300,7 @@ CircleAvatar(
 }
 ```
 
-#### family_invitations
+#### invitations
 ```json
 {
   "id": "invitation_uuid",
@@ -333,10 +333,9 @@ CircleAvatar(
 #### Invitation Management
 ```json
 {
-  "collectionGroup": "family_invitations",
+  "collectionGroup": "invitations",
   "fields": [
     {"fieldPath": "familyId", "order": "ASCENDING"},
-    {"fieldPath": "status", "order": "ASCENDING"},
     {"fieldPath": "createdAt", "order": "DESCENDING"}
   ]
 }

--- a/docs/technical/fixes/FIREBASE_FIRESTORE_FIXES.md
+++ b/docs/technical/fixes/FIREBASE_FIRESTORE_FIXES.md
@@ -104,20 +104,10 @@ type '_Map<String, dynamic>' is not a subtype of type 'String'
       ]
     },
     {
-      "collectionGroup": "family_invitations",
+      "collectionGroup": "invitations",
       "queryScope": "COLLECTION",
       "fields": [
         {"fieldPath": "familyId", "order": "ASCENDING"},
-        {"fieldPath": "status", "order": "ASCENDING"},
-        {"fieldPath": "createdAt", "order": "DESCENDING"}
-      ]
-    },
-    {
-      "collectionGroup": "family_invitations",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {"fieldPath": "invitedEmail", "order": "ASCENDING"},
-        {"fieldPath": "status", "order": "ASCENDING"},
         {"fieldPath": "createdAt", "order": "DESCENDING"}
       ]
     }
@@ -139,9 +129,8 @@ type '_Map<String, dynamic>' is not a subtype of type 'String'
 - `familyId + role + joinedAt`: Get family members by role, sorted by join date
 - `familyId + isActive + role`: Filter active members by role
 
-**Family Invitations**:
-- `familyId + status + createdAt`: Manage family invitations by status
-- `invitedEmail + status + createdAt`: Track user's invitation history
+**Invitations**:
+- `familyId + createdAt`: Manage invitations by family, newest first
 
 ### 2. **Storage Service Type Safety**
 
@@ -484,8 +473,8 @@ service cloud.firestore {
     }
     
     // Invitation access control
-    match /family_invitations/{invitationId} {
-      allow read: if request.auth != null && 
+    match /invitations/{invitationId} {
+      allow read: if request.auth != null &&
         (resource.data.inviterUserId == request.auth.uid ||
          resource.data.invitedEmail == request.auth.token.email);
     }

--- a/docs/technical/fixes/FIREBASE_FIRESTORE_FIXES.md
+++ b/docs/technical/fixes/FIREBASE_FIRESTORE_FIXES.md
@@ -108,6 +108,16 @@ type '_Map<String, dynamic>' is not a subtype of type 'String'
       "queryScope": "COLLECTION",
       "fields": [
         {"fieldPath": "familyId", "order": "ASCENDING"},
+        {"fieldPath": "status", "order": "ASCENDING"},
+        {"fieldPath": "createdAt", "order": "DESCENDING"}
+      ]
+    },
+    {
+      "collectionGroup": "invitations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "invitedEmail", "order": "ASCENDING"},
+        {"fieldPath": "status", "order": "ASCENDING"},
         {"fieldPath": "createdAt", "order": "DESCENDING"}
       ]
     }
@@ -130,7 +140,8 @@ type '_Map<String, dynamic>' is not a subtype of type 'String'
 - `familyId + isActive + role`: Filter active members by role
 
 **Invitations**:
-- `familyId + createdAt`: Manage invitations by family, newest first
+- `familyId + status + createdAt`: Manage invitations by status
+- `invitedEmail + status + createdAt`: Track user's invitation history
 
 ### 2. **Storage Service Type Safety**
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -87,7 +87,21 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "invitations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "familyId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []
-} 
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -97,6 +97,28 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "invitations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "invitedEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "createdAt",
           "order": "DESCENDING"
         }


### PR DESCRIPTION
## Summary
- add composite index for `invitations` collection
- update Firestore docs for new invitation index
- update family system doc to use `invitations` path

## Testing
- `./quick_test.sh` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ea01912c8323be083ebde3781160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect the renaming of the Firestore collection from "family_invitations" to "invitations".
  - Revised examples and index configuration details to match the new collection name and simplified index structure.
  - Updated Firestore security rules documentation to use the new collection path.

- **Chores**
  - Added new Firestore indexes for the "invitations" collection with optimized fields for improved query performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->