### PR TITLE
Add global settings menu overlay

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'screens/premium_features_screen.dart';
 import 'screens/data_export_screen.dart';
 import 'screens/offline_mode_settings_screen.dart';
 import 'screens/disposal_facilities_screen.dart';
+import 'widgets/global_settings_menu.dart';
 import 'widgets/navigation_wrapper.dart';
 import 'utils/constants.dart'; // For app constants, themes, and strings
 import 'utils/error_handler.dart'; // Correct import for ErrorHandler
@@ -298,6 +299,18 @@ class WasteSegregationApp extends StatelessWidget {
           theme: AppTheme.lightTheme,
           darkTheme: AppTheme.darkTheme,
           themeMode: themeProvider.themeMode,
+          builder: (context, child) {
+            return Stack(
+              children: [
+                if (child != null) child,
+                Positioned(
+                  top: MediaQuery.of(context).padding.top + 8,
+                  right: 8,
+                  child: const GlobalSettingsMenu(),
+                ),
+              ],
+            );
+          },
           
           // ADD ROUTE DEFINITIONS:
           routes: {

--- a/lib/widgets/global_settings_menu.dart
+++ b/lib/widgets/global_settings_menu.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import '../screens/settings_screen.dart';
+import '../screens/profile_screen.dart';
+import '../utils/simplified_navigation_service.dart';
+
+class GlobalSettingsMenu extends StatelessWidget {
+  const GlobalSettingsMenu({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return PopupMenuButton<String>(
+      icon: Icon(
+        Icons.more_vert,
+        color: theme.colorScheme.onSurface,
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      onSelected: (value) {
+        switch (value) {
+          case 'settings':
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => const SettingsScreen()),
+            );
+            break;
+          case 'profile':
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => const ProfileScreen()),
+            );
+            break;
+          case 'help':
+            _showHelpDialog(context);
+            break;
+          case 'about':
+            _showAboutDialog(context);
+            break;
+          case 'sign_out':
+            SimplifiedNavigationService.showSignOutConfirmation(context);
+            break;
+        }
+      },
+      itemBuilder: (context) => const [
+        PopupMenuItem(
+          value: 'settings',
+          child: Row(
+            children: [
+              Icon(Icons.settings, color: Colors.grey),
+              SizedBox(width: 12),
+              Text('Settings'),
+            ],
+          ),
+        ),
+        PopupMenuItem(
+          value: 'profile',
+          child: Row(
+            children: [
+              Icon(Icons.person, color: Colors.grey),
+              SizedBox(width: 12),
+              Text('Profile'),
+            ],
+          ),
+        ),
+        PopupMenuDivider(),
+        PopupMenuItem(
+          value: 'help',
+          child: Row(
+            children: [
+              Icon(Icons.help_outline, color: Colors.blue),
+              SizedBox(width: 12),
+              Text('Help & Support'),
+            ],
+          ),
+        ),
+        PopupMenuItem(
+          value: 'about',
+          child: Row(
+            children: [
+              Icon(Icons.info_outline, color: Colors.blue),
+              SizedBox(width: 12),
+              Text('About'),
+            ],
+          ),
+        ),
+        PopupMenuDivider(),
+        PopupMenuItem(
+          value: 'sign_out',
+          child: Row(
+            children: [
+              Icon(Icons.logout, color: Colors.red),
+              SizedBox(width: 12),
+              Text('Sign Out', style: TextStyle(color: Colors.red)),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _showHelpDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Help & Support'),
+        content: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('How to use WasteWise:'),
+            SizedBox(height: 8),
+            Text('1. Take a photo or upload an image of waste'),
+            Text('2. Get AI-powered classification'),
+            Text('3. Follow disposal instructions'),
+            Text('4. Earn points and achievements'),
+            SizedBox(height: 16),
+            Text('Need more help? Check the Settings for tutorials and guides.'),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const SettingsScreen()),
+              );
+            },
+            child: const Text('Settings'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showAboutDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('About WasteWise'),
+        content: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('WasteWise - Smart Waste Classification'),
+            SizedBox(height: 8),
+            Text('Version 1.0.0'),
+            SizedBox(height: 8),
+            Text('An AI-powered app to help you classify and manage waste properly.'),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `GlobalSettingsMenu` widget replicating home screen menu
- inject the menu into every page via `MaterialApp.builder`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448c7de52883238309728a07895c95