### PR TITLE
Remove old social toggle

### DIFF
--- a/lib/screens/social_screen.dart
+++ b/lib/screens/social_screen.dart
@@ -23,75 +23,7 @@ class _SocialScreenState extends State<SocialScreen> {
     
     return Scaffold(
       appBar: _currentIndex == 1 ? AppBar(
-        title: const Text('Social'),
-        bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(70),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-            child: Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(25),
-              ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => setState(() => _currentIndex = 0),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        decoration: BoxDecoration(
-                          color: _currentIndex == 0
-                              ? Theme.of(context).colorScheme.primary
-                              : Colors.transparent,
-                          borderRadius: BorderRadius.circular(25),
-                        ),
-                        child: Text(
-                          'Community',
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            color: _currentIndex == 0
-                                ? Theme.of(context).colorScheme.onPrimary
-                                : Theme.of(context).textTheme.bodyLarge?.color,
-                            fontWeight: _currentIndex == 0
-                                ? FontWeight.bold
-                                : FontWeight.normal,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => setState(() => _currentIndex = 1),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        decoration: BoxDecoration(
-                          color: _currentIndex == 1
-                              ? Theme.of(context).colorScheme.primary
-                              : Colors.transparent,
-                          borderRadius: BorderRadius.circular(25),
-                        ),
-                        child: Text(
-                          'Family',
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            color: _currentIndex == 1
-                                ? Theme.of(context).colorScheme.onPrimary
-                                : Theme.of(context).textTheme.bodyLarge?.color,
-                            fontWeight: _currentIndex == 1
-                                ? FontWeight.bold
-                                : FontWeight.normal,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
+        title: const Text('Family'),
       ) : null,
       body: IndexedStack(
         index: _currentIndex,


### PR DESCRIPTION
## Summary
- clean up SocialScreen
- remove toggle bar on Family view

## Testing
- `./scripts/testing/quick_test.sh` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448bd0603c8323b8ec785481d7a65b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the AppBar on the social screen by removing the segmented control tabs and related interactive elements. The AppBar now displays only a static "Family" title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->