### PR TITLE
Fix invitation queries with new Firestore index

### DIFF
--- a/docs/technical/fixes/FIREBASE_FIRESTORE_FIXES.md
+++ b/docs/technical/fixes/FIREBASE_FIRESTORE_FIXES.md
@@ -20,6 +20,7 @@ The query requires an index. You can create it here: https://console.firebase.go
 **Affected Queries**:
 - Family member filtering by `familyId + role + joinedAt`
 - Invitation management by `familyId + status + createdAt`
+- Invitation list sorting by `familyId + createdAt`
 - Analytics events by `userId + eventType + timestamp`
 - Disposal locations by `source + isActive + name`
 
@@ -141,6 +142,7 @@ type '_Map<String, dynamic>' is not a subtype of type 'String'
 
 **Invitations**:
 - `familyId + status + createdAt`: Manage invitations by status
+- `familyId + createdAt`: Retrieve invitations sorted by creation date
 - `invitedEmail + status + createdAt`: Track user's invitation history
 
 ### 2. **Storage Service Type Safety**

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -96,14 +96,16 @@
           "fieldPath": "familyId",
           "order": "ASCENDING"
         },
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "createdAt",
-          "order": "DESCENDING"
-        }
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "invitations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "familyId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- add missing `familyId + createdAt` index for invitations
- document invitation index requirement

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448bff75048323b3447995bf2e7a01