### PR TITLE
Fix null invite link crash

### DIFF
--- a/lib/screens/family_invite_screen.dart
+++ b/lib/screens/family_invite_screen.dart
@@ -285,6 +285,10 @@ class _FamilyInviteScreenState extends State<FamilyInviteScreen>
   }
 
   Widget _buildShareLinkTab() {
+    if (_inviteLink == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
     return SingleChildScrollView(
       padding: const EdgeInsets.all(AppTheme.paddingRegular),
       child: Column(
@@ -547,6 +551,7 @@ class _FamilyInviteScreenState extends State<FamilyInviteScreen>
   }
 
   void _copyInviteLink() {
+    if (_inviteLink == null) return;
     Clipboard.setData(ClipboardData(text: _inviteLink!));
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(


### PR DESCRIPTION
## Summary
- handle null invite link in `FamilyInviteScreen`
- safeguard copying invite link

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448c4aec0883239d6280ac5bdc4bf2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by displaying a loading indicator when the invite link is not yet available.
  - Prevented errors when copying the invite link if it has not been generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->