### PR TITLE
Enhance analytics charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Waste Segregation App will be documented in this file.
 
+## [2.0.3] - 2025-06-08
+
+### 📈 Analytics Improvements
+- Added animated FL_Chart widgets to complement existing WebView charts
+- Synchronized gamification data during analytics load for consistent points
+
 ## [2.0.2] - 2025-06-06
 
 ### 📚 Documentation Reorganization


### PR DESCRIPTION
## Summary
- add `WasteCategoryPieChart`, `TopSubcategoriesBarChart`, and `WasteTimeSeriesChart` to the analytics dashboard
- sync gamification data when loading analytics
- drive chart animations with a new `AnimationController`
- document analytics improvements in CHANGELOG

## Testing
- `bash scripts/testing/quick_test.sh` *(fails: `dart` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448b383ff083238b730d7e2d147c7a