### PR TITLE
Handle errors when loading user id

### DIFF
--- a/lib/screens/contribution_history_screen.dart
+++ b/lib/screens/contribution_history_screen.dart
@@ -24,12 +24,24 @@ class _ContributionHistoryScreenState extends State<ContributionHistoryScreen> {
   }
 
   Future<void> _loadCurrentUserId() async {
-    final storage = context.read<StorageService>();
-    final profile = await storage.getCurrentUserProfile();
-    if (!mounted) return;
-    setState(() {
-      _currentUserId = profile?.id ?? 'guest_user';
-    });
+    try {
+      final storage = context.read<StorageService>();
+      final profile = await storage.getCurrentUserProfile();
+      if (!mounted) return;
+      setState(() {
+        _currentUserId = profile?.id ?? 'guest_user';
+      });
+    } catch (e, stack) {
+      if (mounted) {
+        setState(() {
+          _currentUserId = 'guest_user';
+        });
+      } else {
+        _currentUserId = 'guest_user';
+      }
+      debugPrint('Failed to load current user id: $e');
+      debugPrint('$stack');
+    }
   }
   
   @override


### PR DESCRIPTION
## Summary
- wrap `_loadCurrentUserId` in a try/catch block
- default to guest user and log errors when failing to load the user profile

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684503d06040832384fcc7b35ac3b316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when loading user information, ensuring the app gracefully falls back to a guest user if an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->