### PR TITLE
Improve error handling for user id fetch

### DIFF
--- a/lib/screens/contribution_history_screen.dart
+++ b/lib/screens/contribution_history_screen.dart
@@ -24,12 +24,23 @@ class _ContributionHistoryScreenState extends State<ContributionHistoryScreen> {
   }
 
   Future<void> _loadCurrentUserId() async {
-    final storage = context.read<StorageService>();
-    final profile = await storage.getCurrentUserProfile();
-    if (!mounted) return;
-    setState(() {
-      _currentUserId = profile?.id ?? 'guest_user';
-    });
+    try {
+      final storage = context.read<StorageService>();
+      final profile = await storage.getCurrentUserProfile();
+      if (!mounted) return;
+      setState(() {
+        _currentUserId = profile?.id ?? 'guest_user';
+      });
+    } catch (e) {
+      debugPrint('Error loading current user id: $e');
+      if (!mounted) {
+        _currentUserId = 'guest_user';
+        return;
+      }
+      setState(() {
+        _currentUserId = 'guest_user';
+      });
+    }
   }
   
   @override


### PR DESCRIPTION
## Summary
- guard against failures when loading the current user id

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450e675dc48323abfcc1acfb09c92f