### PR TITLE
Enhance analytics charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Waste Segregation App will be documented in this file.
 
+## [2.0.3] - 2025-06-08
+
+### 📈 Analytics Improvements
+- Added animated FL_Chart widgets to complement existing WebView charts
+- Synchronized gamification data during analytics load for consistent points
+
 ## [2.0.2] - 2025-06-06
 
 ### 📚 Documentation Reorganization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Waste Segregation App will be documented in this file
 ### 📈 Analytics Improvements
 - Added animated FL_Chart widgets to complement existing WebView charts
 - Synchronized gamification data during analytics load for consistent points
+- Fixed activity chart overflow by removing redundant WebView and using typed ChartData
 
 ## [2.0.2] - 2025-06-06
 

--- a/docs/guides/developer_guide.md
+++ b/docs/guides/developer_guide.md
@@ -191,7 +191,7 @@ TopSubcategoriesBarChart(
 
 // Create line chart for time series
 WasteTimeSeriesChart(
-  data: timeSeriesData,
+  data: timeSeriesData, // List<ChartData>
   animationController: _animationController,
 );
 ```

--- a/lib/widgets/waste_chart_widgets.dart
+++ b/lib/widgets/waste_chart_widgets.dart
@@ -672,13 +672,13 @@ class WeeklyItemsChart extends StatelessWidget {
 
 /// A line chart widget for displaying waste generation over time
 class WasteTimeSeriesChart extends StatelessWidget {
-  
+
   const WasteTimeSeriesChart({
     super.key,
     required this.data,
     required this.animationController,
   });
-  final List<Map<String, dynamic>> data;
+  final List<ChartData> data;
   final AnimationController animationController;
   
   @override
@@ -690,7 +690,7 @@ class WasteTimeSeriesChart extends StatelessWidget {
     }
     
     // Calculate the maximum value for scaling
-    final maxValue = data.map((item) => item['count'] as int).reduce((a, b) => a > b ? a : b).toDouble();
+    final maxValue = data.map((item) => item.value).reduce((a, b) => a > b ? a : b);
     
     return AnimatedBuilder(
       animation: animationController,
@@ -706,7 +706,7 @@ class WasteTimeSeriesChart extends StatelessWidget {
                     if (itemIndex >= 0 && itemIndex < data.length) {
                       final item = data[itemIndex];
                       return LineTooltipItem(
-                        '${item['formattedDate']}\n',
+                        '${item.label}\n',
                         const TextStyle(
                           color: Colors.white,
                           fontWeight: FontWeight.bold,
@@ -714,7 +714,7 @@ class WasteTimeSeriesChart extends StatelessWidget {
                         ),
                         children: [
                           TextSpan(
-                            text: 'Items: ${item['count']}',
+                            text: 'Items: ${item.value.toInt()}',
                             style: const TextStyle(
                               color: Colors.white,
                               fontSize: 12,
@@ -743,11 +743,11 @@ class WasteTimeSeriesChart extends StatelessWidget {
                     if (index < 0 || index >= data.length) {
                       return const SizedBox.shrink();
                     }
-                    
+
                     return SideTitleWidget(
                       axisSide: meta.axisSide,
                       child: Text(
-                        data[index]['formattedDate'] as String,
+                        data[index].label,
                         style: const TextStyle(
                           fontSize: 12,
                           fontWeight: FontWeight.bold,
@@ -796,8 +796,8 @@ class WasteTimeSeriesChart extends StatelessWidget {
                 spots: List.generate(
                   data.length,
                   (index) => FlSpot(
-                    index.toDouble(), 
-                    (data[index]['count'] as int).toDouble() * animationController.value,
+                    index.toDouble(),
+                    data[index].value * animationController.value,
                   ),
                 ),
                 isCurved: true,


### PR DESCRIPTION
## Summary
- add `WasteCategoryPieChart`, `TopSubcategoriesBarChart`, and `WasteTimeSeriesChart` to the analytics dashboard
- sync gamification data when loading analytics
- drive chart animations with a new `AnimationController`
- document analytics improvements in CHANGELOG

## Testing
- `bash scripts/testing/quick_test.sh` *(fails: `dart` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448b383ff083238b730d7e2d147c7a