### PR TITLE
Fix location dialog maps call

### DIFF
--- a/lib/widgets/interactive_tag.dart
+++ b/lib/widgets/interactive_tag.dart
@@ -247,9 +247,9 @@ class InteractiveTag extends StatelessWidget {
             child: const Text('Close'),
           ),
           TextButton(
-            onPressed: () {
+            onPressed: () async {
               Navigator.of(context).pop();
-              _openMaps();
+              await _openMaps();
             },
             child: const Text('Get Directions'),
           ),


### PR DESCRIPTION
## Summary
- handle Get Directions button asynchronously

## Testing
- `./scripts/testing/quick_test.sh` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fe569e388323b6b8d72cada4fbf2