### PR TITLE
Handle debug logging in error boundary

### DIFF
--- a/lib/widgets/error_boundary.dart
+++ b/lib/widgets/error_boundary.dart
@@ -39,7 +39,8 @@ class _ErrorBoundaryState extends State<ErrorBoundary> {
       
       // Log error
       if (kDebugMode) {
-        debugPrint('🚨 Error Boundary Caught: ${details.exception}'); // TODO: Remove or guard for production
+        // Only log to console in debug mode
+        debugPrint('🚨 Error Boundary Caught: ${details.exception}');
       } else {
         FirebaseCrashlytics.instance.recordFlutterFatalError(details);
       }


### PR DESCRIPTION
## Summary
- remove stray TODO comment in ErrorBoundary
- explain that debug printing is only enabled in debug mode

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684539180fd083239ee0bae28c01db18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed outdated internal comments from error handling logic. No impact on app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->