### PR TITLE
Fix settings menu overlay

### DIFF
--- a/lib/widgets/global_menu_wrapper.dart
+++ b/lib/widgets/global_menu_wrapper.dart
@@ -10,10 +10,14 @@ class GlobalMenuWrapper extends StatelessWidget {
     return Stack(
       children: [
         child,
-        Positioned(
-          top: MediaQuery.of(context).padding.top + 8,
-          right: 8,
-          child: const GlobalSettingsMenu(),
+        SafeArea(
+          child: Align(
+            alignment: Alignment.topRight,
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: const GlobalSettingsMenu(),
+            ),
+          ),
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- avoid overlapping system areas with SafeArea

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845392a14c08323afc159a71a55bb69