### PR TITLE
Add haptic feedback toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ For comprehensive documentation including setup guides, technical details, and p
 - **[🔧 Technical Documentation](docs/technical/README.md)** - Recent fixes and technical details
 - **[🧪 Testing Guide](docs/testing/TESTING_GUIDE.md)** - Comprehensive testing documentation and best practices
 - **[📱 UX/UI 2025 Task List](docs/design/user_experience/mobile_ux_ui_2025_tasks.md)** - Actions from latest mobile best practices research
+- **[📱 UX Improvements Task List (2025)](docs/design/user_experience/ux_2025_custom_tasks.md)** - Fine-grained UX tasks for upcoming work
 - **[📋 Resolution Plan](docs/planning/RESOLUTION_PLAN.md)** - Priority issues and fixes
 - **[🗺️ Project Roadmap](docs/planning/roadmap/unified_project_roadmap.md)** - Development roadmap and timeline
 - **[❓ Troubleshooting](docs/reference/troubleshooting.md)** - Common issues and solutions
@@ -914,6 +915,7 @@ For comprehensive documentation including setup guides, technical details, and p
 - **[🔧 Technical Documentation](docs/technical/README.md)** - Recent fixes and technical details
 - **[🧪 Testing Guide](docs/testing/TESTING_GUIDE.md)** - Comprehensive testing documentation and best practices
 - **[📱 UX/UI 2025 Task List](docs/design/user_experience/mobile_ux_ui_2025_tasks.md)** - Actions from latest mobile best practices research
+- **[📱 UX Improvements Task List (2025)](docs/design/user_experience/ux_2025_custom_tasks.md)** - Fine-grained UX tasks for upcoming work
 - **[📋 Resolution Plan](docs/planning/RESOLUTION_PLAN.md)** - Priority issues and fixes
 - **[🗺️ Project Roadmap](docs/planning/roadmap/unified_project_roadmap.md)** - Development roadmap and timeline
 - **[❓ Troubleshooting](docs/reference/troubleshooting.md)** - Common issues and solutions

--- a/docs/design/user_experience/ux_2025_custom_tasks.md
+++ b/docs/design/user_experience/ux_2025_custom_tasks.md
@@ -1,0 +1,16 @@
+# UX Improvements Task List (2025)
+
+This file tracks specific user experience tasks derived from the 2025 mobile UX research. Each task has an ID, title, definition of done, and difficulty indicator.
+
+| ID | Title | Definition of Done | Difficulty |
+| --- | --- | --- | --- |
+| UX-01 | Adaptive Layout Refactor | Home & History respond correctly at 360 dp, 600 dp (rail), 840 dp (list-detail) with golden tests. | ⚙️ Medium |
+| UX-02 | Dynamic Color + Dark Mode | `ThemeData` switches via `MediaQuery.platformBrightness`; contrast ratios ≥ 4.5:1 verified. | ⚙️ Medium |
+| UX-03 | Complete Semantics Pass | 100 % tappables labelled; no `flutter analyze --fatal-warnings` a11y issues. | 🔧 Easy |
+| UX-04 | Camera Overlay & Pinch-Zoom | Grid overlay toggle + pinch-zoom on both Android & iOS; unit test records zoom value. | ⚙️ Medium |
+| UX-05 | Progressive Onboarding | First-run flow with skip button, persisted in `SharedPreferences`; A/B test enable flag. | ⚙️ Medium |
+| UX-06 | Empty-State Illustrations | Replace blank screens with Lottie animations and contextual CTAs. | 🔧 Easy |
+| UX-07 | i18n Pipeline Setup | All strings extracted, Hindi/Kannada bundles added; language picker in settings. | ⚙️ Medium |
+| UX-08 | Haptic Success Feedback | `HapticFeedback.lightImpact()` on positive scan; user toggle in settings. | 🔧 Easy |
+
+Each task should be implemented as an isolated pull request with appropriate tests or documentation updates.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'services/premium_service.dart';
 import 'services/ad_service.dart';
 import 'services/user_consent_service.dart';
 import 'services/navigation_settings_service.dart';
+import 'services/haptic_settings_service.dart';
 import 'services/community_service.dart';
 import 'screens/auth_screen.dart';
 import 'screens/consent_dialog_screen.dart';
@@ -182,6 +183,7 @@ Future<void> originalMain() async {
   final adService = AdService();
   final googleDriveService = GoogleDriveService(storageService);
   final navigationSettingsService = NavigationSettingsService();
+  final hapticSettingsService = HapticSettingsService();
   final communityService = CommunityService();
 
   try {
@@ -212,6 +214,7 @@ Future<void> originalMain() async {
       adService: adService,
       googleDriveService: googleDriveService,
       navigationSettingsService: navigationSettingsService,
+      hapticSettingsService: hapticSettingsService,
       communityService: communityService,
     ));
     if (kDebugMode) {
@@ -272,6 +275,7 @@ class WasteSegregationApp extends StatelessWidget {
     required this.premiumService,
     required this.adService,
     required this.navigationSettingsService,
+    required this.hapticSettingsService,
     required this.communityService,
   });
   final StorageService storageService;
@@ -284,6 +288,7 @@ class WasteSegregationApp extends StatelessWidget {
   final PremiumService premiumService;
   final AdService adService;
   final NavigationSettingsService navigationSettingsService;
+  final HapticSettingsService hapticSettingsService;
   final CommunityService communityService;
 
   @override
@@ -306,6 +311,7 @@ class WasteSegregationApp extends StatelessWidget {
           ChangeNotifierProvider<PremiumService>.value(value: premiumService),
           ChangeNotifierProvider<AdService>.value(value: adService),
           ChangeNotifierProvider<NavigationSettingsService>.value(value: navigationSettingsService),
+          ChangeNotifierProvider<HapticSettingsService>.value(value: hapticSettingsService),
           Provider<CommunityService>.value(value: communityService),
 
           // Other providers

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../utils/share_service.dart';
 import '../models/waste_classification.dart';
@@ -27,6 +28,7 @@ import '../screens/waste_dashboard_screen.dart';
 import '../widgets/modern_ui/modern_info_tile.dart';
 import '../services/analytics_service.dart';
 import '../screens/image_capture_screen.dart';
+import '../services/haptic_settings_service.dart';
 
 class ResultScreen extends StatefulWidget {
   const ResultScreen({
@@ -182,6 +184,11 @@ class _ResultScreenState extends State<ResultScreen>
           content: Text(syncMessage),
           backgroundColor: Colors.green,
         ));
+
+        final haptic = context.read<HapticSettingsService>();
+        if (haptic.enabled && widget.classification.category != 'Requires Manual Review') {
+          HapticFeedback.lightImpact();
+        }
       }
 
     } catch (e, stackTrace) {
@@ -277,6 +284,11 @@ class _ResultScreenState extends State<ResultScreen>
           backgroundColor: Colors.green,
         ),
       );
+
+      final haptic = context.read<HapticSettingsService>();
+      if (haptic.enabled && widget.classification.category != 'Requires Manual Review') {
+        HapticFeedback.lightImpact();
+      }
     } catch (e, stackTrace) {
       ErrorHandler.handleError(e, stackTrace);
       setState(() => _isAutoSaving = false);

--- a/lib/services/haptic_settings_service.dart
+++ b/lib/services/haptic_settings_service.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class HapticSettingsService extends ChangeNotifier {
+  HapticSettingsService() {
+    _load();
+  }
+
+  static const String _enabledKey = 'haptic_success_enabled';
+  bool _enabled = true;
+
+  bool get enabled => _enabled;
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _enabled = prefs.getBool(_enabledKey) ?? true;
+    notifyListeners();
+  }
+
+  Future<void> setEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_enabledKey, value);
+    _enabled = value;
+    notifyListeners();
+  }
+}

--- a/lib/widgets/settings/app_settings_section.dart
+++ b/lib/widgets/settings/app_settings_section.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../screens/theme_settings_screen.dart';
 import '../../screens/notification_settings_screen.dart';
 import '../../screens/offline_mode_settings_screen.dart';
 import '../../screens/data_export_screen.dart';
+import '../../services/haptic_settings_service.dart';
 import 'setting_tile.dart';
 import 'settings_theme.dart';
 
@@ -51,6 +53,19 @@ class AppSettingsSection extends StatelessWidget {
           title: 'Data Export',
           subtitle: 'Export your data and history',
           onTap: () => _navigateToDataExport(context),
+        ),
+
+        Consumer<HapticSettingsService>(
+          builder: (context, hapticSettings, child) {
+            return SettingToggleTile(
+              icon: Icons.vibration,
+              iconColor: Colors.orange,
+              title: 'Haptic Feedback',
+              subtitle: 'Vibrate on successful scan',
+              value: hapticSettings.enabled,
+              onChanged: hapticSettings.setEnabled,
+            );
+          },
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- add `HapticSettingsService`
- expose haptic setting in `AppSettingsSection`
- persist setting via provider
- trigger light haptic feedback on successful classification saves

## Testing
- `git status --short`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c212419308323a39fc7ee5180387c