### PR TITLE
Fix intl package version conflict with flutter_localizations

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   fl_chart: ^1.0.0  # Updated to new major version with new API
   # REPLACED: flutter_markdown (discontinued) with markdown_widget
   markdown_widget: ^2.3.2+6  # Community-maintained alternative with rich features
-  intl: ^0.20.2  # For internationalization and date formatting
+  intl: any  # For internationalization and date formatting (version managed by flutter_localizations)
   webview_flutter: ^4.13.0  # Updated to latest
   # Updated Firebase dependencies with web-compatible versions
   firebase_core: ^3.14.0  # Updated to latest


### PR DESCRIPTION
Fixes dependency version conflict that was causing CI/CD build failures. Changed intl dependency from ^0.20.2 to 'any' to let flutter_localizations manage the version. This resolves the conflict where flutter_localizations from Flutter SDK requires a specific intl version that conflicts with explicit version constraints. Maintains all intl functionality for date formatting and internationalization while ensuring compatibility with Flutter SDK requirements.