### PR TITLE
Fix instant analysis save logic to persist classifications in Hive

### DIFF
--- a/lib/screens/instant_analysis_screen.dart
+++ b/lib/screens/instant_analysis_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 
 import '../models/waste_classification.dart';
 import '../services/ai_service.dart';
+import '../services/gamification_service.dart';
 import '../widgets/enhanced_analysis_loader.dart';
 import '../screens/result_screen.dart';
 
@@ -66,7 +67,13 @@ class _InstantAnalysisScreenState extends State<InstantAnalysisScreen> {
       }
 
       if (!_isCancelled && mounted) {
-        debugPrint('Navigation to results screen with classification');
+        debugPrint('✅ Analysis complete - saving classification immediately');
+        
+        // Save the classification immediately using gamification service to trigger all hooks
+        final gamificationService = Provider.of<GamificationService>(context, listen: false);
+        await gamificationService.processClassification(result!);
+        
+        debugPrint('✅ Classification saved - navigating to results screen');
         
         // Navigate to results screen and wait for it to complete
         await Navigator.pushReplacement<void, void>(

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -81,6 +81,7 @@ class _ResultScreenState extends State<ResultScreen>
       'item_name': widget.classification.itemName,
       'show_actions': widget.showActions,
       'confidence': widget.classification.confidence,
+      'auto_analyze': widget.autoAnalyze,
     });
     
     _animationController = AnimationController(
@@ -89,8 +90,16 @@ class _ResultScreenState extends State<ResultScreen>
     );
     
     // Process the classification for gamification only if it's a new classification
-    if (widget.showActions) {
+    // Skip auto-save processing for autoAnalyze mode since it's already saved in InstantAnalysisScreen
+    if (widget.showActions && !widget.autoAnalyze) {
       _autoSaveAndProcess();
+    } else if (widget.autoAnalyze) {
+      // For autoAnalyze mode, the classification is already saved and processed
+      // Just mark it as saved and show the UI
+      debugPrint('🚀 AUTO-ANALYZE: Classification already saved in InstantAnalysisScreen, skipping auto-save');
+      setState(() {
+        _isSaved = true;
+      });
     } else {
       // 🎮 GAMIFICATION FIX: For existing classifications, check if they need 
       // retroactive gamification processing (fixes the 2/10 classifications but 0 points issue)


### PR DESCRIPTION
Fixes critical issue where instant analysis classifications were never saved to Hive, leaving history empty. **Root Cause**: InstantAnalysisScreen bypassed all save logic by navigating directly to ResultScreen without calling saveClassification() or processClassification(). **Solution**: 1) Save classification immediately in InstantAnalysisScreen after AI analysis using gamificationService.processClassification() to trigger all hooks, 2) Update ResultScreen to skip auto-save processing when autoAnalyze=true since classification is already saved, 3) Mark classification as saved in ResultScreen for autoAnalyze mode to show correct UI state. **Result**: Instant analysis classifications now appear in history, trigger gamification hooks, and maintain all functionality while preserving the streamlined UX.