### PR TITLE
Fix: Complete GitHub Issue #137 - Premium Navigation with Named Routes

### DIFF
--- a/lib/screens/theme_settings_screen.dart
+++ b/lib/screens/theme_settings_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers.dart';
-import 'premium_features_screen.dart';
+import '../utils/routes.dart';
 
 class ThemeSettingsScreen extends ConsumerWidget {
   const ThemeSettingsScreen({super.key});
@@ -94,12 +94,7 @@ class ThemeSettingsScreen extends ConsumerWidget {
               subtitle: const Text('Unlock advanced theme customization and more'),
               trailing: const Icon(Icons.chevron_right),
               onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const PremiumFeaturesScreen(),
-                  ),
-                );
+                Navigator.pushNamed(context, Routes.premium);
               },
             ),
           ),
@@ -145,13 +140,8 @@ class ThemeSettingsScreen extends ConsumerWidget {
           ElevatedButton(
             onPressed: () {
               Navigator.pop(context);
-              // Navigate to premium features screen
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const PremiumFeaturesScreen(),
-                ),
-              );
+              // Navigate to premium features screen using named route
+              Navigator.pushNamed(context, Routes.premium);
             },
             child: const Text('Upgrade Now'),
           ),

--- a/test/screens/theme_settings_screen_test.dart
+++ b/test/screens/theme_settings_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart' as provider;
 import 'package:waste_segregation_app/screens/theme_settings_screen.dart';
 import 'package:waste_segregation_app/screens/premium_features_screen.dart';
 import 'package:waste_segregation_app/services/premium_service.dart';
@@ -24,6 +25,10 @@ void main() {
       // Set up default mock behavior
       when(mockPremiumService.isPremiumFeature('theme_customization'))
           .thenReturn(false);
+      when(mockPremiumService.getComingSoonFeatures())
+          .thenReturn([]);
+      when(mockPremiumService.getPremiumFeatures())
+          .thenReturn([]);
       when(mockThemeProvider.themeMode).thenReturn(ThemeMode.system);
     });
 
@@ -147,7 +152,10 @@ void main() {
               initialRoute: '/',
               routes: {
                 '/': (_) => const ThemeSettingsScreen(),
-                '/premium': (_) => const PremiumFeaturesScreen(),
+                '/premium': (context) => provider.ChangeNotifierProvider<PremiumService>.value(
+                  value: mockPremiumService,
+                  child: const PremiumFeaturesScreen(),
+                ),
               },
             ),
           ),


### PR DESCRIPTION
Completes GitHub issue #137 by implementing proper named route navigation from Theme Settings to Premium Features screen. Changes: Replace Navigator.push with Navigator.pushNamed(context, Routes.premium) in settings list-tile, fix widget test with proper provider setup. Testing: Widget test passes, manual navigation works correctly. Documentation: Comprehensive docs in GITHUB_ISSUE_137_PREMIUM_NAVIGATION_FIX.md. Closes #137